### PR TITLE
Feature/aaduszki changes commited from 03 aug2022

### DIFF
--- a/sbn-fd/DAQInterface/VeryHighRate_Boot_27EBs.template
+++ b/sbn-fd/DAQInterface/VeryHighRate_Boot_27EBs.template
@@ -1,0 +1,169 @@
+DAQ setup script: $SETUP_FILE
+PMT host: localhost
+
+# debug level can range from 0 to 3 (increasing order of verbosity)
+debug level: 4
+#manage processes: false
+Subsystem id: 1
+
+# EVENT BUILDERS
+
+EventBuilder host: icarus-evb01-daq
+EventBuilder label: EventBuilder1
+
+EventBuilder host: icarus-evb01-daq
+EventBuilder label: EventBuilder6
+
+EventBuilder host: icarus-evb01-daq
+EventBuilder label: EventBuilder11
+
+# Add 4 more event builders on  icarus-evb02-daq
+EventBuilder host: icarus-evb02-daq
+EventBuilder label: EventBuilder2
+
+EventBuilder host: icarus-evb02-daq
+EventBuilder label: EventBuilder7
+
+EventBuilder host: icarus-evb02-daq
+EventBuilder label: EventBuilder12
+
+EventBuilder host: icarus-evb02-daq
+EventBuilder label: EventBuilder16
+
+EventBuilder host: icarus-evb02-daq
+EventBuilder label: EventBuilder20
+
+EventBuilder host: icarus-evb02-daq
+EventBuilder label: EventBuilder24
+
+# Add 3 more event builders on  icarus-evb03-daq
+EventBuilder host: icarus-evb03-daq
+EventBuilder label: EventBuilder3
+
+EventBuilder host: icarus-evb03-daq
+EventBuilder label: EventBuilder8
+
+EventBuilder host: icarus-evb03-daq
+EventBuilder label: EventBuilder13
+
+EventBuilder host: icarus-evb03-daq
+EventBuilder label: EventBuilder17
+
+EventBuilder host: icarus-evb03-daq
+EventBuilder label: EventBuilder21
+
+EventBuilder host: icarus-evb03-daq
+EventBuilder label: EventBuilder25
+
+# Add 3 more event builders on  icarus-evb04-daq
+EventBuilder host: icarus-evb04-daq
+EventBuilder label: EventBuilder4
+
+EventBuilder host: icarus-evb04-daq
+EventBuilder label: EventBuilder9
+
+EventBuilder host: icarus-evb04-daq
+EventBuilder label: EventBuilder14
+
+EventBuilder host: icarus-evb04-daq
+EventBuilder label: EventBuilder18
+
+EventBuilder host: icarus-evb04-daq
+EventBuilder label: EventBuilder22
+
+EventBuilder host: icarus-evb04-daq
+EventBuilder label: EventBuilder26
+
+# Add 3 more event builders on  icarus-evb05-daq
+EventBuilder host: icarus-evb05-daq
+EventBuilder label: EventBuilder5
+
+EventBuilder host: icarus-evb05-daq
+EventBuilder label: EventBuilder10
+
+EventBuilder host: icarus-evb05-daq
+EventBuilder label: EventBuilder15
+
+EventBuilder host: icarus-evb05-daq
+EventBuilder label: EventBuilder19
+
+EventBuilder host: icarus-evb05-daq
+EventBuilder label: EventBuilder23
+
+EventBuilder host: icarus-evb05-daq
+EventBuilder label: EventBuilder27
+
+# DATA LOGGERS
+
+#DataLogger host: icarus-evb01-daq
+#DataLogger label: DataLogger1
+
+#DataLogger host: icarus-evb01-daq
+#DataLogger label: DataLogger2
+
+#DataLogger host: icarus-evb01-daq
+#DataLogger label: DataLogger3
+
+#DataLogger host: icarus-evb01-daq
+#DataLogger label: DataLogger4
+
+#DataLogger host: icarus-evb01-daq
+#DataLogger label: DataLogger5
+
+# Add 5 more data logger on icarus-evb02-daq
+#DataLogger host: icarus-evb02-daq
+#DataLogger label: DataLogger6
+
+#DataLogger host: icarus-evb02-daq
+#DataLogger label: DataLogger7
+
+#DataLogger host: icarus-evb02-daq
+#DataLogger label: DataLogger8
+
+#DataLogger host: icarus-evb02-daq
+#DataLogger label: DataLogger9
+
+#DataLogger host: icarus-evb02-daq
+#DataLogger label: DataLogger10
+
+# Add 5 more loggers on  icarus-evb03-daq
+#DataLogger host: icarus-evb03-daq
+#DataLogger label: DataLogger11
+
+#DataLogger host: icarus-evb03-daq
+#DataLogger label: DataLogger12
+
+#DataLogger host: icarus-evb03-daq
+#DataLogger label: DataLogger13
+
+#DataLogger host: icarus-evb03-daq
+#DataLogger label: DataLogger14
+
+#DataLogger host: icarus-evb03-daq
+#DataLogger label: DataLogger15
+
+# Add 5 more loggers on  icarus-evb04-daq
+#DataLogger host: icarus-evb04-daq
+#DataLogger label: DataLogger16
+
+#DataLogger host: icarus-evb04-daq
+#DataLogger label: DataLogger17
+
+#DataLogger host: icarus-evb04-daq
+#DataLogger label: DataLogger18
+
+#DataLogger host: icarus-evb04-daq
+#DataLogger label: DataLogger19
+
+#DataLogger host: icarus-evb04-daq
+#DataLogger label: DataLogger20
+
+Dispatcher host: icarus-evb01-daq
+Dispatcher label: Dispatcher1
+# port number must be unique accros all partitions
+Dispatcher port: 6020
+
+#RoutingManager host:  icarus-evb01-daq
+#RoutingManager label: RoutingManager1
+#RoutingManager target: DataLogger
+

--- a/sbn-fd/DAQInterface/VeryHighRate_Boot_9EBs.template
+++ b/sbn-fd/DAQInterface/VeryHighRate_Boot_9EBs.template
@@ -1,0 +1,115 @@
+DAQ setup script: $SETUP_FILE
+PMT host: localhost
+
+# debug level can range from 0 to 3 (increasing order of verbosity)
+debug level: 4
+#manage processes: false
+Subsystem id: 1
+
+# EVENT BUILDERS
+
+EventBuilder host: icarus-evb01-daq
+EventBuilder label: EventBuilder1
+
+# Add 2 more event builders on  icarus-evb02-daq
+EventBuilder host: icarus-evb02-daq
+EventBuilder label: EventBuilder2
+
+EventBuilder host: icarus-evb02-daq
+EventBuilder label: EventBuilder6
+
+# Add 2 more event builders on  icarus-evb03-daq
+EventBuilder host: icarus-evb03-daq
+EventBuilder label: EventBuilder3
+
+EventBuilder host: icarus-evb03-daq
+EventBuilder label: EventBuilder7
+
+# Add 2 more event builders on  icarus-evb04-daq
+EventBuilder host: icarus-evb04-daq
+EventBuilder label: EventBuilder4
+
+EventBuilder host: icarus-evb04-daq
+EventBuilder label: EventBuilder8
+
+# Add 2 more event builders on  icarus-evb05-daq
+EventBuilder host: icarus-evb05-daq
+EventBuilder label: EventBuilder5
+
+EventBuilder host: icarus-evb05-daq
+EventBuilder label: EventBuilder9
+
+# DATA LOGGERS
+
+#DataLogger host: icarus-evb01-daq
+#DataLogger label: DataLogger1
+
+#DataLogger host: icarus-evb01-daq
+#DataLogger label: DataLogger2
+
+#DataLogger host: icarus-evb01-daq
+#DataLogger label: DataLogger3
+
+#DataLogger host: icarus-evb01-daq
+#DataLogger label: DataLogger4
+
+#DataLogger host: icarus-evb01-daq
+#DataLogger label: DataLogger5
+
+# Add 5 more data logger on icarus-evb02-daq
+#DataLogger host: icarus-evb02-daq
+#DataLogger label: DataLogger6
+
+#DataLogger host: icarus-evb02-daq
+#DataLogger label: DataLogger7
+
+#DataLogger host: icarus-evb02-daq
+#DataLogger label: DataLogger8
+
+#DataLogger host: icarus-evb02-daq
+#DataLogger label: DataLogger9
+
+#DataLogger host: icarus-evb02-daq
+#DataLogger label: DataLogger10
+
+# Add 5 more loggers on  icarus-evb03-daq
+#DataLogger host: icarus-evb03-daq
+#DataLogger label: DataLogger11
+
+#DataLogger host: icarus-evb03-daq
+#DataLogger label: DataLogger12
+
+#DataLogger host: icarus-evb03-daq
+#DataLogger label: DataLogger13
+
+#DataLogger host: icarus-evb03-daq
+#DataLogger label: DataLogger14
+
+#DataLogger host: icarus-evb03-daq
+#DataLogger label: DataLogger15
+
+# Add 5 more loggers on  icarus-evb04-daq
+#DataLogger host: icarus-evb04-daq
+#DataLogger label: DataLogger16
+
+#DataLogger host: icarus-evb04-daq
+#DataLogger label: DataLogger17
+
+#DataLogger host: icarus-evb04-daq
+#DataLogger label: DataLogger18
+
+#DataLogger host: icarus-evb04-daq
+#DataLogger label: DataLogger19
+
+#DataLogger host: icarus-evb04-daq
+#DataLogger label: DataLogger20
+
+Dispatcher host: icarus-evb01-daq
+Dispatcher label: Dispatcher1
+# port number must be unique accros all partitions
+Dispatcher port: 6020
+
+#RoutingManager host:  icarus-evb01-daq
+#RoutingManager label: RoutingManager1
+#RoutingManager target: DataLogger
+

--- a/sbn-fd/DAQInterface/boot_MinBias_VeryHighRate.txt
+++ b/sbn-fd/DAQInterface/boot_MinBias_VeryHighRate.txt
@@ -1,1 +1,1 @@
-VeryHighRate_Boot.template
+VeryHighRate_Boot_27EBs.template

--- a/sbn-fd/DAQInterface/boot_MinBias_VeryHighRate_multiple_art_processes.txt
+++ b/sbn-fd/DAQInterface/boot_MinBias_VeryHighRate_multiple_art_processes.txt
@@ -1,0 +1,1 @@
+VeryHighRate_Boot_9EBs.template

--- a/sbn-fd/DAQInterface/known_boardreaders_list
+++ b/sbn-fd/DAQInterface/known_boardreaders_list
@@ -83,10 +83,10 @@ icarustpcew01b icarus-tpc18-daq -1 1
 icarustpcew01m icarus-tpc18-daq -1 1
 icarustpcew01t icarus-tpc18-daq -1 1
 icarustpcew02 icarus-tpc18-daq -1 1
-icarustpcew03 icarus-tpc17-daq -1 1
-icarustpcew04 icarus-tpc17-daq -1 1
-icarustpcew05 icarus-tpc17-daq -1 1
-icarustpcew06 icarus-tpc17-daq -1 1
+icarustpcew03 icarus-tpc26-daq -1 1
+icarustpcew04 icarus-tpc26-daq -1 1
+icarustpcew05 icarus-tpc26-daq -1 1
+icarustpcew06 icarus-tpc26-daq -1 1
 icarustpcew07 icarus-tpc16-daq -1 1
 icarustpcew08 icarus-tpc16-daq -1 1
 icarustpcew09 icarus-tpc16-daq -1 1

--- a/sbn-fd/DAQInterface/setup_sbn_artdaq_local.sh
+++ b/sbn-fd/DAQInterface/setup_sbn_artdaq_local.sh
@@ -43,9 +43,19 @@ export TRACE_FILE=/tmp/trace_$(whoami)_p1
 
 echo "TRACE_FILE=$TRACE_FILE"
 
-toffSg 9-63   # suppress debug++ messages to Slow path
+#start with turning off everything
+toffSg 0-63
+toffMg 0-63
+
+#turn on what we need
 tonSg 0-8     # ton* does not suppress other levels
 tonMg 0-8
+
+#if you want to see debug++ messages, ton levels 9 and/or above
+#S - slow path and message viewer
+#M - memory trace
+
+#toffSg 9-63   # suppress debug++ messages to Slow path
 #toffM 1-63 -n PhysCrateData
 #toffS 1-63 -n PhysCrateData
 
@@ -60,6 +70,26 @@ tonMg 0-8
 #tonS 0-debug -n ICARUSTriggerUDP
 tmodeS 1
 tmodeM 1
+
+#Examples to turn on/off messages coming from specific machines and specific classes
+
+#if [[ "$(hostname -s)" =~ icarus-evb[0-9]{2} ]]; then
+#toffM -N *_SharedMemoryEventManager 0-63
+#toffM -N ArtdaqSharedMemoryService 0-63
+#toffM -N SharedMemoryEventReceiver 0-63
+#toffM -N SharedMemoryManager 0-63
+#toffM -N *RootDAQOut 0-63
+#toffM -N MetricManager 0-63
+#toffM -N TCPConnect 0-63
+#toffM -N EventBuilder1_art1_FragmentWatcher 0-63
+#tonM -N EventBuilder1_art1_FragmentWatcher DEBUG+1
+#tonS -N EventBuilder1_art1_FragmentWatcher DEBUG+1
+#fi
+#
+#if [[ "$(hostname -s)" =~ icarus-pmt[0-9]{2} ]]; then
+#tonS -N *CAENV1730Readout  9
+#tonM -N *CAENV1730Readout  9
+#fi
 
 
 #toffM 23 -n SharedMemoryManager

--- a/sbn-fd/DAQInterface/trace_control.sh
+++ b/sbn-fd/DAQInterface/trace_control.sh
@@ -181,5 +181,6 @@ esac
 
 status=$?
 echo; echo "`date`: exiting with status $status"
+echo "`date`: exiting with status $status" >> ~/trace.log
 exit $status
 


### PR DESCRIPTION
### Description

Includes changes made in the shifter area 03Aug2022:

• Boot configuration for ~5Hz (varying number of event builders). The best working configuration is with 9 boardreaders: 1 on icarus-evb01 and 2 on icarus-evb02–05, and 10 art processes for each of them.
• Changed boardreader configuration needed to move TPC readout from failed server 17 to server 26
• Saving DAQ stop time to gather information needed to understand why it takes long to stop

### Testing details
We're about to start tests, to be updated