### PR TITLE
Update ICARUS pmt_standard for storage

### DIFF
--- a/sbn-fd/DAQInterface/configs/standard/pmt_standard.fcl
+++ b/sbn-fd/DAQInterface/configs/standard/pmt_standard.fcl
@@ -2,112 +2,160 @@ daq:
 {
   fragment_receiver: 
   {
+
     generator:   CAENV1730Readout
-    max_fragment_size_bytes: 1000000
     fragment_type: CAENV1730
+    max_fragment_size_bytes: 30000000
     GetNextFragmentBunchSize: 20
 
-    fragment_id: 0 
-    board_id:   0 
+    # these don't exist as fcl parameters?
+    fragment_id: 0
+    board_id:    0
+    
     Verbosity: 1
     SWTrigger: false
 
-    # calibration
+    # begin run ADC calibration
     CalibrateOnConfig: true
+    
+    # read and write some calibration parameters
+    AdcCalibration: false
 
     # Turn on or off automatic mid-run temperature correction
-    LockTempCalibration: false
+    LockTempCalibration: true
 
-    # ModeLVDS 0:REGISTER, 1:TRIGGER, 2:nBUSY/nVETO, 3:LEGACY
+    # ModeLVDS 0=REGISTER, 1=TRIGGER, 2=nBUSY/nVETO, 3=LEGACY
+    # SBND: keep this parameter = 0
     ModeLVDS: 1
 
+    # new fcl parameters added by ICARUS
     # Aiwu added here to set LVDS logic values: 3: logics OR, 0: logic AND; (not so clear about 1 and 2)
-    LVDSLogicValueG1: 3
-    LVDSLogicValueG2: 3
-    LVDSLogicValueG3: 3
-    LVDSLogicValueG4: 3
-    LVDSLogicValueG5: 3
-    LVDSLogicValueG6: 3
-    LVDSLogicValueG7: 3
-    LVDSLogicValueG8: 3
-    # Aiwu added here to set LVDS output width: N*8ns will be the width!
-    LVDSOutWidthC1: 20
-    LVDSOutWidthC2: 20
-    LVDSOutWidthC3: 20
-    LVDSOutWidthC4: 20
-    LVDSOutWidthC5: 20
-    LVDSOutWidthC6: 20
-    LVDSOutWidthC7: 20
-    LVDSOutWidthC8: 20
-    LVDSOutWidthC9: 20
-    LVDSOutWidthC10: 20
-    LVDSOutWidthC11: 20
-    LVDSOutWidthC12: 20
-    LVDSOutWidthC13: 20
-    LVDSOutWidthC14: 20
-    LVDSOutWidthC15: 20
-    LVDSOutWidthC16: 20
-    # Aiwu added here: self trigger plority, it is 0x10 (or 16 in decimal, or 0010000) by default, we want to change bit[6] from 0 to 1, so 0x30 (or 80 in decimal, or 1010000)
-    SelfTrigBit: 16
+    # Exclusive for ICARUS
+     LVDSLogicValueG1: 3
+     LVDSLogicValueG2: 3
+     LVDSLogicValueG3: 3
+     LVDSLogicValueG4: 3
+     LVDSLogicValueG5: 3
+     LVDSLogicValueG6: 3
+     LVDSLogicValueG7: 3
+     LVDSLogicValueG8: 3
+     
+     # Aiwu added here to set LVDS output width: N*8ns will be the width!
+     # Exclusive for ICARUS
+     LVDSOutWidthC1: 20
+     LVDSOutWidthC2: 20
+     LVDSOutWidthC3: 20
+     LVDSOutWidthC4: 20
+     LVDSOutWidthC5: 20
+     LVDSOutWidthC6: 20
+     LVDSOutWidthC7: 20
+     LVDSOutWidthC8: 20
+     LVDSOutWidthC9: 20
+     LVDSOutWidthC10: 20
+     LVDSOutWidthC11: 20
+     LVDSOutWidthC12: 20
+     LVDSOutWidthC13: 20
+     LVDSOutWidthC14: 20
+     LVDSOutWidthC15: 20
+     LVDSOutWidthC16: 20
+    
+     # Aiwu added here: self trigger plority, it is 0x10 (or 16 in decimal, or 0010000) by default, we want to change bit[6] from 0 to 1, so 0x30 (or 80 in decimal, or 1010000)
+     # Exclusive for ICARUS
+     SelfTrigBit: 16
 
-    # Aiwu add here: DPP algorithm feature, 0x1n80, bit[4]: 0 -> pedestal not used; 1-> pedestal used (add 1024 to ADC count), test
-    # as I read defaul is 0x3840 = 14400; changing only bit[4] get 14416 or 0x3850
-    ChargePedstalBitCh1: 14400
-
-    # SelfTriggerMode 0:Disabled 1:ACQ_ONLY 2:EXTOUT_ONLY 3:ACQ_AND_EXTOUT
+    # SelfTriggerMode: channel auto trigger settings. Since in x730 boards even and odd 
+    # channels are paired, their 'SelfTriggerMode' value will be equal to the 
+    # OR combination of the pair, unless one of the two channels of
+    # the pair is disabled (by 'SelfTriggerMask' parameter). 
+    # If so, the other one behaves as usual.
+    # SelfTriggerMode 0:DISABLED 1:ACQ_ONLY 2:TRGOUT_ONLY 3:ACQ_AND_TRGOUT
     SelfTriggerMode: 0
 
-    # SelfTriggerMask One enable bit for each pair of channels
+    # SelfTriggerMask: the channel mask (16bit-number) you will enable the 'SelfTriggerMode'
+    # Each bit enables/disables one channel
+    # 65535: all channels are enabled
     SelfTriggerMask: 255
 
     # Majority mode logic
     # For level m, the trigger fires when at least m+1 of the enabled trigger pairs fire
-    MajorityLevel: 0
+    # Exclusive for SBND
+    # ICARUS: (should not interfere but) keep this parameter = 0
+    majorityLevel: 0
 
-    # Time window for the majority coincidence, in 8 nsec ticks (trigger clocks)
-    MajorityCoincidenceWindow: 1
-    MajorityTimeWindow: 4 
+    # Sets the time window for the majority coincidence in units of the Trigger Clock (8 ns) 
+    # 'majorityLevel' must be set different from 0.
+    # min: 0, max: 15
+    # Exclusive for SBND
+    # ICARUS: (should not interfere but) keep this parameter = 0
+    majorityCoincidenceWindow: 0
+    
+    # Set self trigger logic
+    # triggerLogic 0: AND, 1: ONLYA, 2: ONLYB, 3:OR
+    # Exclusive for SBND
+    # ICARUS: (should not interfere but) keep this parameter = 3
+    triggerLogic: 3
 
-    allowTriggerOverlap: false
+    allowTriggerOverlap: true
 
-    link:0
+    link: 0
     enableReadout: 1
     
     boardId: 0
     recordLength:         5000
     maxEventsPerTransfer: 1
     runSyncMode:          0
+   
     outputSignalMode:     0    
-    usePedestals:         false 
+    usePedestals:         false
     dacValue:             32768
-    #32768
     
     # ioLevel: 0=NIM, 1=TTL
     ioLevel:              1
     nChannels:            16
     
-    # extTrgMode: 0=no external triggers;   3=Front panel TRG input
+    # extTrgMode decides whether the external trigger should only be used to generate the
+    # acquisition trigger, only to generate the trigger output or both
+    # extTrgMode: 0=DISABLED; 1=ACQ_ONLY; 2=TRGOUT_ONLY; 3=ACQ_AND_TRGOUT
     extTrgMode:           3
     
-    # swTrgMode:  0=no software generation; 3=allow software generated trigs
+    # swTrgMode decides whether the trigger software should only be used to generate the 
+    # acquisition trigger, only to generate the trigger output or both. 
+    # you should set 'SWTrigger: true' to enable software triggers
+    # swTrgMode:  0=DISABLED; 1=ACQ_ONLY; 2=TRGOUT_ONLY; 3=ACQ_AND_TRGOUT
     swTrgMode:            0
-    # Write whatever value to generate a software trigger (address 0x8108)
-    # SWTriggerValue: 1
     
     # acqMode: 0=Software Controlled, 1=Front Panel S_IN
     acqMode:              0
     
-    triggerPolarity:      0   
+    # triggerPolarity: 0=positive (trigger on rising edge), 1= negative (trigger on falling edge)
+    # Exclusive for SBND
+    # ICARUS: (should not interfere but) keep this parameter = 0
+    triggerPolarity:      0 
+    
+       
     debugLevel:           7
-    postPercent:          0
+    postPercent:          70
+
+    # Use or not use the interrupts
+    InterruptEnable: 0
+    # Timeout value
+    IRQTimeoutMS: 100
+    
     eventsPerInterrupt:   1
     irqWaitTime:          1
     eventCounterWarning:  1       
     memoryAlmostFull:     2    
     
     readoutMode:          0
-    analogMode:           1
     testPattern:          0
+    
+    # SBND: MTC/A input
+    # See CAEN User Manual UM2792, page 51
+    # trigger majority mode: 0; test mode (saw-tooth signal with 1V amplitude): 1 
+    # buffer ocuppancy mode: 3; voltage level mode: 4 
+    analogMode:           1
+    
+
     channelPedestal0:  6554
     channelPedestal1:  6554
     channelPedestal2:  6554
@@ -125,25 +173,6 @@ daq:
     channelPedestal14: 6554
     channelPedestal15: 6554
 
-    # baseline (dc offset). It is a 32 bit value, but bit[31:16] are reserved, 
-    # we should only change the lower 16 bits bit[15:0]
-    # not to use yet, the pedestal settings above seem to work for this dc offset.
-    BaselineCh1: 14000
-    BaselineCh2: 14000
-    BaselineCh3: 14000
-    BaselineCh4: 14000
-    BaselineCh5: 14000
-    BaselineCh6: 14000
-    BaselineCh7: 14000
-    BaselineCh8: 14000
-    BaselineCh9: 14000
-    BaselineCh10: 14000
-    BaselineCh11: 14000
-    BaselineCh12: 14000
-    BaselineCh13: 14000
-    BaselineCh14: 14000
-    BaselineCh15: 14000
-    BaselineCh16: 14000
 
     channelEnable0:    true
     channelEnable1:    true
@@ -162,74 +191,99 @@ daq:
     channelEnable14:   true
     channelEnable15:   true
 
+    # Trigger pulse width for TRG_OUT and MON outputs
+    # Width will be (triggerPulseWidth)*8ns
+    # Exclusive for SBND, ICARUS keep to 20
     triggerPulseWidth: 20
     
     BoardChainNumber: 0
+    GetNextSleep: 10
+
     InterruptLevel: 0
     InterruptStatusID: 0
     InterruptEventNumber: 1
-    GetNextSleep: 100
-    
+
     CombineReadoutWindows: false
 
     # 0 = 2 V dynamic range, 1 = 0.5 V 
     # register 0x8028
     dynamicRange: 0 
 
-    triggerThreshold0:  14800
-    triggerThreshold1:  14800
-    triggerThreshold2:  14800
-    triggerThreshold3:  14800
-    triggerThreshold4:  14979
-    triggerThreshold5:  14840
-    triggerThreshold6:  14908
-    triggerThreshold7:  14866
-    triggerThreshold8:  14763
-    triggerThreshold9:  14930
-    triggerThreshold10: 14889
-    triggerThreshold11: 14926
-    triggerThreshold12: 14873
-    triggerThreshold13: 14972
-    triggerThreshold14: 14834
-    triggerThreshold15: 14800
-
-#    triggerThreshold0:  0
-#    triggerThreshold1:  0
-#    triggerThreshold2:  0
-#    triggerThreshold3:  0
-#    triggerThreshold4:  0
-#    triggerThreshold5:  0
-#    triggerThreshold6:  0
-#    triggerThreshold7:  0
-#    triggerThreshold8:  0
-#    triggerThreshold9:  0
-#    triggerThreshold10: 0
-#    triggerThreshold11: 0
-#    triggerThreshold12: 0
-#    triggerThreshold13: 0
-#    triggerThreshold14: 0
-#    triggerThreshold15: 0
+    # these are overwritten by each board
+    triggerThreshold0:  0
+    triggerThreshold1:  0
+    triggerThreshold2:  0
+    triggerThreshold3:  0
+    triggerThreshold4:  0
+    triggerThreshold5:  0
+    triggerThreshold6:  0
+    triggerThreshold7:  0
+    triggerThreshold8:  0
+    triggerThreshold9:  0
+    triggerThreshold10: 0
+    triggerThreshold11: 0
+    triggerThreshold12: 0
+    triggerThreshold13: 0
+    triggerThreshold14: 0
+    triggerThreshold15: 0
 
     CircularBufferSize: 500e6
 
-    UseTimeTagForTimeStamp: false
+    # added just because it's in the ICARUS config file
     TimeOffsetNanoSec: 0
-
+    
     destinations: { }
 
     routing_table_config: {
       use_routing_master: false 
     }
 
-    #pull mode configuration	
-    receive_requests: true
-    request_address:        "227.128.12.35" # -- multicast request address
-    multicast_interface_ip: "192.168.191.0" # -- should match the private net 
-    request_port: 3502   # UDP request port
-    request_mode: sequence #match sequenceID of request
-    data_buffer_depth_fragments: 10000
-    data_buffer_depth_mb: 2000
-    #stale_request_timeout: 100000000000 #100s #turn off to default to no timeout
+    circular_buffer_mode: true 
+
+    receive_requests: true 
+
+    # -- multicast request address
+    request_address: "227.128.12.35" 
+
+    # -- should match the private net
+    multicast_interface_ip: "192.168.191.0" 
+   
+    # -- should match the private net 
+    request_port: 3502 # UDP request port
+    
+    #window: request over a set time interval
+    request_mode: window 
+
+    # Alow use of NPT server time to form fragment timestamp and TriggerTimeTag
+    UseTimeTagForTimeStamp: true 
+   
+    # Size of the request window (3 ms, covers 2 ms expected plus a little bit)
+    request_window_width: 3000000 
+    
+    # Start 1.5 ms before
+    request_window_offset: 1500000 
+
+    # We want our fragments to appear multiple times in our request window if necessary
+    request_windows_are_unique: true 
+
+    # True for pull modes
+    separate_data_thread: true 
+   
+    # Max waiting time for new fragments (2 second, too large/small?!) also not sure and keep commented
+    stale_fragment_timeout: 2000000000 
+
+    # Max waiting time before the board reader sends the fragments in its buffer
+    window_close_timeout_us: 3000e3 
+
+    data_buffer_depth_fragments: 20000 
+
+    data_buffer_depth_mb: 4000 
+
+    poll_hardware_status: true 
+
+    hardware_poll_interval_us: 1e6 
+
+    separate_monitoring_thread: true 
 
   }  
 
@@ -238,44 +292,21 @@ daq:
     brFile: {
       metricPluginType: "file"
       level: 3
-      fileName: "/daq/log/metrics/br_%UID%_metrics.log"
+      fileName: "/scratch/log/br_%UID%_metrics.log"
       uniquify: true
     }
-    graphite:{
+    
+    send_system_metrics: true
+    send_process_metrics: true
+
+    graphite: {
       namespace: "icarus.icaruspmt00."
-      host: "192.168.191.18"
+      host: "192.168.191.31"
       level: 10
       metricPluginType: "graphite"
       port: 2003
       reporting_interval: 10
     }
-
-    # redis_10s: {
-    #       metricPluginType: "redis"
-    #   level: 3
-    #   reporting_interval: 10.0
-    #   redis_key_postfix: ":10s" 
-    #   maxlen: 10000
-    #   redis_key_prefix: "DABBoardReader:pmtx01:"
-    #   redis_passfile: "/var/adm/krb5/redis_password"
-    # }
-    # redis_testing: {
-    #   metricPluginType: "redis"
-    #   level: 3
-    #   reporting_interval: 30.0
-    #   redis_key_postfix: ":testing"
-    #   maxlen: 10000
-    #   redis_key_prefix: "DABBoardReader:pmtx01:"
-    #   redis_passfile: "/var/adm/krb5/redis_password"
-    # }
-    # redis_5m: {
-    #   metricPluginType: "redis"
-    #   level: 3
-    #   reporting_interval: 300.0
-    #   redis_key_postfix: ":5m" 
-    #   maxlen: 10000
-    #   redis_key_prefix: "DABBoardReader:pmtx01:"
-    #   redis_passfile: "/var/adm/krb5/redis_password"
-    # }
+   
   }
 }

--- a/sbn-fd/DAQInterface/configs/standard/pmt_standard.fcl
+++ b/sbn-fd/DAQInterface/configs/standard/pmt_standard.fcl
@@ -270,10 +270,10 @@ daq:
     separate_data_thread: true 
    
     # Max waiting time for new fragments (2 second, too large/small?!) also not sure and keep commented
-    stale_fragment_timeout: 2000000000 
+    stale_fragment_timeout: 10000000000 #Feb 22, 2023 AA, increased to 10s in hope to remove empty fragments
 
     # Max waiting time before the board reader sends the fragments in its buffer
-    window_close_timeout_us: 3000e3 
+    window_close_timeout_us: 10000e3
 
     data_buffer_depth_fragments: 20000 
 


### PR DESCRIPTION
Related to: https://github.com/SBNSoftware/sbndaq-artdaq/pull/95

Adding ICARUS `pmt_standard.fcl` here just for storage, it will be integrated in the configurations stored in MongoDB.