### PR TITLE
Add dummy generator fcl for SBN-ND

### DIFF
--- a/sbn-nd/DAQInterface/configs/standard/dummygenerator.fcl
+++ b/sbn-nd/DAQInterface/configs/standard/dummygenerator.fcl
@@ -1,0 +1,22 @@
+daq: {
+  fragment_receiver: {
+    time_step_ms:                  337
+    fragment_id:                   0x3300
+    generated_fragments_per_event: 1
+
+    # Advanced memory managment
+    max_fragment_size_bytes: 128
+
+    fragment_type: DUMMYGENERATOR
+    generator:     DummyGenerator
+
+    board_id: 1
+    ReaderID: 0x1
+
+    destinations: { }
+    routing_table_config:
+    {
+      use_routing_master: false
+    }
+  }
+}

--- a/sbn-nd/DAQInterface/known_boardreaders_list
+++ b/sbn-nd/DAQInterface/known_boardreaders_list
@@ -31,3 +31,4 @@ pmtx01 sbnd-pds03-daq -1 1 0-15
 pmtx02 sbnd-pds03-daq -1 1 0-15 
 pmtx03 sbnd-pds02-daq -1 1 0-15
 pmtx04 sbnd-pds01-daq -1 1 0-15
+dummygenerator sbnd-evb02-daq -1 1


### PR DESCRIPTION
### Description

In CRT Flat running I was making regular use of the dummy generator as a pushing tool for runs with no sophisticated trigger setup. Thought it would be useful to have an example of a dummy generator fcl in the standard SBN-ND folder for others to use as a base.