### PR TITLE
Fix issues with restarting bottom CRT boardreader

### DIFF
--- a/sbn-fd/DAQInterface/setup_sbn_artdaq.sh
+++ b/sbn-fd/DAQInterface/setup_sbn_artdaq.sh
@@ -26,3 +26,18 @@ toffSg 0-63
 toffMg 0-63
 tonSg 0-8
 tonMg 0-8
+
+if [[ "$(hostname -s)" =~ icarus-crt11 ]]; then
+    echo Checking if the boardreader is running. If not, attempting to kill the Bottom CRT backend
+    if ! /usr/sbin/pidof boardreader ; then
+        if /usr/sbin/pidof bottomCRTreadout ; then
+            echo Attempting to kill the backend
+            /usr/bin/killall bottomCRTreadout
+        else
+            echo Backend not running, no need to kill it
+        fi
+    else
+        echo Boardreader is running, refraining from killing the backend
+    fi
+fi
+

--- a/sbn-fd/DAQInterface/setup_sbn_artdaq_local.sh
+++ b/sbn-fd/DAQInterface/setup_sbn_artdaq_local.sh
@@ -103,3 +103,16 @@ tmodeM 1
 # tonM 15 -n CommandableFragmentGenerator
 
 
+if [[ "$(hostname -s)" =~ icarus-crt11 ]]; then
+    echo Checking if the boardreader is running. If not, attempting to kill the Bottom CRT backend
+    if ! /usr/sbin/pidof boardreader ; then
+        if /usr/sbin/pidof bottomCRTreadout ; then
+            echo Attempting to kill the backend
+            /usr/bin/killall bottomCRTreadout
+        else
+            echo Backend not running, no need to kill it
+        fi
+    else
+        echo Boardreader is running, refraining from killing the backend
+    fi
+fi


### PR DESCRIPTION
### Description

Fixes issue with the daq not starting if the old backend is running. It turns out that the backend, as a child process of the boardreader, binds to the port to XMLRPC. For this reason, a new instance of boardreader cannot start. It is therefore impossible to kill the old instances of the backend from the boardreader. In this pull request the backend is killed in the setup script.

### Related Repository Branches

sbndaq_artdaq PR#123

### Testing details
- *Where it was tested*: SBN-FD
- *Run number associated with test*:  10710, 10711
